### PR TITLE
Add GPU support for Guppy

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -42,7 +42,7 @@ process {
     container = 'quay.io/biocontainers/pysam:0.15.3--py27hda2845c_1'
   }
   withName:Guppy {
-    container = 'genomicpariscentre/guppy:3.2.2'
+    container = 'nanozoo/guppy_gpu:3.2.2-1--e90fbfe'
   }
   withName:pycoQC {
     container = 'quay.io/biocontainers/pycoqc:2.2.4--py_0'

--- a/conf/base.config
+++ b/conf/base.config
@@ -42,7 +42,9 @@ process {
     container = 'quay.io/biocontainers/pysam:0.15.3--py27hda2845c_1'
   }
   withName:Guppy {
-    container = 'nanozoo/guppy_gpu:3.2.2-1--e90fbfe'
+    //container = 'genomicpariscentre/guppy:3.2.2'
+    //container = 'nanozoo/guppy_gpu:3.2.2-1--e90fbfe'
+    container = 'replikation/guppy_gpu:latest'
   }
   withName:pycoQC {
     container = 'quay.io/biocontainers/pycoqc:2.2.4--py_0'

--- a/conf/base.config
+++ b/conf/base.config
@@ -42,9 +42,11 @@ process {
     container = 'quay.io/biocontainers/pysam:0.15.3--py27hda2845c_1'
   }
   withName:Guppy {
-    //container = 'genomicpariscentre/guppy:3.2.2'
-    //container = 'nanozoo/guppy_gpu:3.2.2-1--e90fbfe'
-    container = 'replikation/guppy_gpu:latest'
+    if (params.guppyGPU) {
+      container = 'nanozoo/guppy_gpu:3.2.2-1--e90fbfe'
+    } else {
+      container = 'genomicpariscentre/guppy:3.2.2'
+    }
   }
   withName:pycoQC {
     container = 'quay.io/biocontainers/pycoqc:2.2.4--py_0'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,6 +17,9 @@
   * [`--flowcell`](#--flowcell)
   * [`--kit`](#--kit)
   * [`--barcode_kit`](#--barcode_kit)
+  * [`--guppyGPU`](#--guppygpu)
+  * [`--gpu_device`](#--gpu_device)
+  * [`--gpu_cluster_options`](#--gpu_cluster_options)
   * [`--skipDemultiplexing`](#--skipdemultiplexing)
 * [Alignments](#alignments)
   * [`--aligner`](#--aligner)
@@ -156,6 +159,15 @@ Kit used to perform the sequencing e.g. `SQK-LSK109`
 
 ### `--barcode_kit`
 Barcode kit used to perform the sequencing e.g. `SQK-PBK004`
+
+### `--guppyGPU`
+Whether to demultiplex with Guppy in GPU mode
+
+### `--gpu_device`
+Basecalling device specified to Guppy in GPU mode using '--device' (default: 'auto')
+
+### `--gpu_cluster_options`
+Cluster options required to use GPU resources (e.g. '--part=gpu --gres=gpu:1')
 
 ### `--skipDemultiplexing`
 Skip basecalling and demultiplexing step with Guppy

--- a/main.nf
+++ b/main.nf
@@ -32,6 +32,7 @@ def helpMessage() {
       --kit                         Kit used to perform the sequencing e.g. SQK-LSK109
       --barcode_kit                 Barcode kit used to perform the sequencing e.g. SQK-PBK004
       --guppyGPU                    Whether to demultiplex with Guppy in GPU mode
+      --gpu_device                  Basecalling device specified to Guppy in GPU mode using '--device' (default: 'auto')
       --gpu_cluster_options         Cluster options required to use GPU resources (e.g. '--part=gpu --gres=gpu:1')
       --skipDemultiplexing          Skip basecalling and demultiplexing step with Guppy
 
@@ -115,6 +116,7 @@ if (!params.skipDemultiplexing){
     summary['Kit ID']             = params.kit
     summary['Barcode Kit ID']     = params.barcode_kit
     summary['Guppy GPU Mode']     = params.guppyGPU ? 'Yes' : 'No'
+    summary['Guppy GPU Device']   = params.gpu_device
     summary['Guppy GPU Options']  = params.gpu_cluster_options
 }
 summary['Skip Alignment']         = params.skipAlignment ? 'Yes' : 'No'
@@ -211,7 +213,7 @@ if (!params.skipDemultiplexing){
         file "*.{log,js}"
 
         script:
-        def proc_options = params.guppyGPU ? "-x auto --num_callers $task.cpus --cpu_threads_per_caller 1 --gpu_runners_per_device 6" : "--num_callers 2 --cpu_threads_per_caller ${task.cpus/2}"
+        def proc_options = params.guppyGPU ? "--device $params.gpu_device --num_callers $task.cpus --cpu_threads_per_caller 1 --gpu_runners_per_device 6" : "--num_callers 2 --cpu_threads_per_caller ${task.cpus/2}"
         """
         guppy_basecaller \\
             --input_path $run_dir \\

--- a/main.nf
+++ b/main.nf
@@ -220,9 +220,9 @@ if (!params.skipDemultiplexing){
             --flowcell $params.flowcell \\
             --kit $params.kit \\
             --barcode_kits $params.barcode_kit \\
-            $proc_options \\
             --records_per_fastq 0 \\
-            --compress_fastq
+            --compress_fastq \\
+            $proc_options
         guppy_basecaller --version &> guppy.version
 
         ## Concatenate fastq files for each barcode

--- a/main.nf
+++ b/main.nf
@@ -32,7 +32,7 @@ def helpMessage() {
       --kit                         Kit used to perform the sequencing e.g. SQK-LSK109
       --barcode_kit                 Barcode kit used to perform the sequencing e.g. SQK-PBK004
       --guppyGPU                    Whether to demultiplex with Guppy in GPU mode
-      --gpu_cluster_options         Cluster options required to use GPU resources
+      --gpu_cluster_options         Cluster options required to use GPU resources (e.g. '--part=gpu --gres=gpu:1')
       --skipDemultiplexing          Skip basecalling and demultiplexing step with Guppy
 
     Alignment
@@ -211,10 +211,9 @@ if (!params.skipDemultiplexing){
         file "*.{log,js}"
 
         script:
-        def proc_options = params.guppyGPU ? "--num_callers $task.cpus --cpu_threads_per_caller 1 --gpu_runners_per_device 6" : "--num_callers 2 --cpu_threads_per_caller ${task.cpus/2}"
+        def proc_options = params.guppyGPU ? "-x auto --num_callers $task.cpus --cpu_threads_per_caller 1 --gpu_runners_per_device 6" : "--num_callers 2 --cpu_threads_per_caller ${task.cpus/2}"
         """
         guppy_basecaller \\
-            -x auto \\
             --input_path $run_dir \\
             --save_path . \\
             --flowcell $params.flowcell \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,6 +14,8 @@ params {
   flowcell = false
   kit = false
   barcode_kit = false
+  guppyGPU = false
+  gpu_cluster_options = ''
   skipDemultiplexing = false
 
   // Options: Alignment

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,6 +15,7 @@ params {
   kit = false
   barcode_kit = false
   guppyGPU = false
+  gpu_device = 'auto'
   gpu_cluster_options = ''
   skipDemultiplexing = false
 


### PR DESCRIPTION
Many thanks to contributing to nf-core/nanodemux!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/nanodemux branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/nanodemux)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/nanodemux/tree/master/.github/CONTRIBUTING.md

* Add `--guppyGPU` parameter to download GPU-specific image and to use relevant options.
* Add `--gpu_device` parameter to specify device name
* Add `--gpu_cluster_options` option to set `clusterOptions` for GPU devices on separate cluster partition

This is still a WIP to add GPU support but it works at The Crick using a custom Singularity config with the following contents:
```
singularity {
  runOptions = '--nv'
}
```

Cant seem to run CPU and GPU versions of `guppy_basecaller` with the same image (`nanozoo/guppy_gpu:3.2.2-1--e90fbfe`) so pipeline is currently using different images based on whether `--guppyGPU` is provided.